### PR TITLE
Switched to OAuth 2.0 URL required by now.

### DIFF
--- a/AndroidMarketApi/src/com/gc/android/market/api/MarketSession.java
+++ b/AndroidMarketApi/src/com/gc/android/market/api/MarketSession.java
@@ -65,7 +65,7 @@ public class MarketSession {
 
 	public String SERVICE = "android";
 
-	private static final String URL_LOGIN = "https://www.google.com/accounts/ClientLogin";
+	private static final String URL_LOGIN = "https://android.clients.google.com/auth";
 	public static final String ACCOUNT_TYPE_GOOGLE = "GOOGLE";
 	public static final String ACCOUNT_TYPE_HOSTED = "HOSTED";
 	public static final String ACCOUNT_TYPE_HOSTED_OR_GOOGLE = "HOSTED_OR_GOOGLE";


### PR DESCRIPTION
As of 21/10/2015, the Google API is not available anymore by https://www.google.com/accounts/ClientLogin.

See https://developers.google.com/identity/protocols/AuthForInstalledApps for more Info.

This URL works for me.